### PR TITLE
Add url to workflow configuration

### DIFF
--- a/video-processor/src/main/java/de/uhh/l2g/webservices/videoprocessor/service/OpencastApiCall.java
+++ b/video-processor/src/main/java/de/uhh/l2g/webservices/videoprocessor/service/OpencastApiCall.java
@@ -274,6 +274,9 @@ public class OpencastApiCall {
 		processing.put("workflow", workflow);
 		Map<String, String> configuration = new HashMap<String,String>();
 		configuration.put("id",id.toString());
+		// send url of this video-processor instance for callback
+		configuration.put("url", config.getProperty("url.videoconversion"));
+	
 		processing.put("configuration",configuration);
 		
 		String processingAsJson = null;

--- a/video-processor/src/main/resources/config.properties
+++ b/video-processor/src/main/resources/config.properties
@@ -1,3 +1,6 @@
+# url to this instance of the videoprocessor
+url.videoconversion=http://localhost:8081/video-processor/videoconversion
+
 # basic authentication
 basicauth.user=test
 basicauth.pass=test


### PR DESCRIPTION
The url of the videoprocessor (defined in config.properties) is now sent
with the post query, so OC knows where to call without the need to
define this in the OC workflow file. 
This guarantees that multiple videoprocessor instances can talk to one
OC instance.