### PR TITLE
Imagebuilder optimizations

### DIFF
--- a/imagebuilder/src/main/java/de/uhh/l2g/util/L2goImageBuilderServlet.java
+++ b/imagebuilder/src/main/java/de/uhh/l2g/util/L2goImageBuilderServlet.java
@@ -87,7 +87,7 @@ public class L2goImageBuilderServlet extends HttpServlet {
 				imageBuilder.setAdditionalImageStream(additionalImageStream);
 			}
 
-			imageBuilder.setFontSize(40.0f);
+			imageBuilder.setFontSize(32.0f);
 
 			initializeFonts(imageBuilder);
 			

--- a/imagebuilder/src/main/java/de/uhh/l2g/util/SpeakerOnlyL2goImageBuilder.java
+++ b/imagebuilder/src/main/java/de/uhh/l2g/util/SpeakerOnlyL2goImageBuilder.java
@@ -25,7 +25,7 @@ public class SpeakerOnlyL2goImageBuilder extends L2goImageBuilder {
 		
 		// the distance from the image-border to the start of text in pixels
 		this.offsetLeft = 440;
-		this.offsetRight = 347;
+		this.offsetRight = 240;
 	}
 
 	/**

--- a/imagebuilder/src/main/java/de/uhh/l2g/util/SpeakerSlidesL2goImageBuilder.java
+++ b/imagebuilder/src/main/java/de/uhh/l2g/util/SpeakerSlidesL2goImageBuilder.java
@@ -62,8 +62,13 @@ public class SpeakerSlidesL2goImageBuilder extends L2goImageBuilder {
 	    this.g.setFont(this.fontItalic);
 	   	usedLines = this.drawString(this.g, this.institution, this.offsetLeft, institutionPosition, this.maxTextWidth, 2);
 
-    	// the title position is fixed
-	    titlePosition = 206;
+	   	// the title position is relative to the institution position
+        if (usedLines <= 1) {
+        	titlePosition = 206;
+        } else {
+        	titlePosition = 240;
+        }
+	    //titlePosition = 206;
 	  	this.g.setFont(this.fontRegular);
 	  	usedLines = this.drawString(this.g, this.title, this.offsetLeft, titlePosition, this.maxTextWidth, 3);
 	  	


### PR DESCRIPTION
- fix for title and insitutition overlap in some cases
- smaller font size for speaker only
- more space allowed for text