### PR TITLE
Add tenant support

### DIFF
--- a/video-processor/pom.xml
+++ b/video-processor/pom.xml
@@ -99,6 +99,12 @@
         	<artifactId>log4j-web</artifactId>
         	<version>2.8.2</version>
         </dependency>
+        <dependency>
+	    	<groupId>javax.servlet</groupId>
+		    <artifactId>servlet-api</artifactId>
+		    <version>2.5</version>
+		    <scope>provided</scope>
+		</dependency>
     </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/video-processor/src/main/java/de/uhh/l2g/webservices/videoprocessor/dao/GenericDao.java
+++ b/video-processor/src/main/java/de/uhh/l2g/webservices/videoprocessor/dao/GenericDao.java
@@ -1,6 +1,7 @@
 package de.uhh.l2g.webservices.videoprocessor.dao;
 
 import java.util.List;
+import java.util.Map;
 
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
@@ -8,6 +9,7 @@ import javax.persistence.Persistence;
 import javax.persistence.TypedQuery;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 
 /**
@@ -66,17 +68,52 @@ public class GenericDao {
 	}
 	
 	/**
+	 * Gets an singluar entity from the database with the given multiple field values
+	 * @param type the class of the entity
+	 * @param fieldsValuesMap the map with an arbitray amount of field-value pairs
+	 * @return the entity (null if not found)
+	 */
+	public <T> T getSingularByMultipleFieldsValues(Class<T> type, Map<String,Object> fieldsValuesMap) {
+		// return only the first element (we use a random order field as this does not play a role here)
+		return getFirstByMultipleFieldsValuesOrderedDesc(type,fieldsValuesMap,(String) fieldsValuesMap.keySet().toArray()[0]);		
+	}
+	
+	/**
 	 * Gets entities for an entity class if field-value matches
 	 * @param type the class of the entity
 	 * @return a list with all filtered entities
 	 */
-	public <T> List<T> getByFieldValue(Class<T> type, String field, Long value) {
+	public <T> List<T> getByFieldValue(Class<T> type, String field, Object value) {
 		EntityManager em = getEntityManager();
 		CriteriaBuilder builder = em.getCriteriaBuilder();
 		CriteriaQuery<T> criteriaQuery = builder.createQuery(type);
 		Root<T> rootEntry = criteriaQuery.from(type);
         CriteriaQuery<T> all = criteriaQuery.select(rootEntry);
         all.where(builder.equal(rootEntry.get(field), value));
+		TypedQuery<T> allQuery = em.createQuery(all);
+		List<T> entities = allQuery.getResultList();
+		em.close();
+		return entities;
+	}	
+	
+	/**
+	 * Gets entities for an entity class if the list of field-values matches
+	 * @param type the class of the entity
+	 * @param fieldsValuesMap the map with an arbitray amount of field-value pairs
+	 * @return a list with all filtered entities
+	 */
+	public <T> List<T> getByMultipleFieldsValues(Class<T> type, Map<String,Object> fieldsValuesMap) {
+		// TODO: add multiple fields
+		EntityManager em = getEntityManager();
+		CriteriaBuilder builder = em.getCriteriaBuilder();
+		CriteriaQuery<T> criteriaQuery = builder.createQuery(type);
+		Root<T> rootEntry = criteriaQuery.from(type);
+        CriteriaQuery<T> all = criteriaQuery.select(rootEntry);
+     
+        // use an arbitray amount of field values pairs for where clause
+        Predicate[] predicates = getPredicatesFromMap(builder, rootEntry, fieldsValuesMap);
+        all.where(predicates);
+
 		TypedQuery<T> allQuery = em.createQuery(all);
 		List<T> entities = allQuery.getResultList();
 		em.close();
@@ -98,6 +135,29 @@ public class GenericDao {
 		Root<T> rootEntry = criteriaQuery.from(type);
         CriteriaQuery<T> all = criteriaQuery.select(rootEntry);
         all.where(builder.equal(rootEntry.get(field), value));
+        all.orderBy(builder.desc(rootEntry.get(orderField)));
+		TypedQuery<T> allQuery = em.createQuery(all);
+		List<T> entities = allQuery.getResultList();
+		em.close();
+		return entities;
+	}
+	
+	/**
+	 * Gets entities for an entity class if field-value matches ordered by orderField (DESC)
+	 * @param type the class of the entity
+	 * @param fieldsValuesMap the map with an arbitray amount of field-value pairs
+	 * @param orderField the field which is used to order the results
+	 * @return a list with all filtered entities
+	 */
+	public <T> List<T> getByMultipleFieldsValuesOrderedDesc(Class<T> type, Map<String, Object> fieldsValuesMap, String orderField) {
+		EntityManager em = getEntityManager();
+		CriteriaBuilder builder = em.getCriteriaBuilder();
+		CriteriaQuery<T> criteriaQuery = builder.createQuery(type);
+		Root<T> rootEntry = criteriaQuery.from(type);
+        CriteriaQuery<T> all = criteriaQuery.select(rootEntry);
+        // use an arbitray amount of field values pairs for where clause
+        Predicate[] predicates = getPredicatesFromMap(builder, rootEntry, fieldsValuesMap);
+        all.where(predicates);
         all.orderBy(builder.desc(rootEntry.get(orderField)));
 		TypedQuery<T> allQuery = em.createQuery(all);
 		List<T> entities = allQuery.getResultList();
@@ -140,6 +200,21 @@ public class GenericDao {
 		}
 	}
 	
+	/**
+	 * Gets the first entity of a list if field-value matches
+	 * @param type the class of the entity
+	 * @param fieldsValuesMap the map with an arbitray amount of field-value pairs
+	 * @param orderField the field which is used to order the results
+	 * @return the first element of a list of filtered entities
+	 */
+	public <T> T getFirstByMultipleFieldsValuesOrderedDesc(Class<T> type, Map<String, Object> fieldsValuesMap, String orderField) {
+		List<T> entities = getByMultipleFieldsValuesOrderedDesc(type, fieldsValuesMap, orderField);
+		if (entities.isEmpty()) {
+			return null;
+		} else {
+			return entities.get(0);
+		}
+	}
 	
 	/**
 	 * Gets all entities for an entity class
@@ -222,5 +297,25 @@ public class GenericDao {
 		}
 		em.getTransaction().commit();
 		em.close();
+	}
+	
+	/**
+	 * Returns an array of predicates for filtering criteria-queries
+	 * @param builder the CriteriaBuilder
+	 * @param rootEntry the Root Criteria
+	 * @param fieldsValuesMap the hashmap with key value pairs
+	 * @return an array with predicates for further processing
+	 */
+	private <T> Predicate[] getPredicatesFromMap(CriteriaBuilder builder, Root<T> rootEntry, Map<String, Object> fieldsValuesMap) {
+		Predicate[] predicateArray = new Predicate[fieldsValuesMap.size()];        
+        int counter = 0;
+        for (String k : ((Map<String, Object>) fieldsValuesMap).keySet()) {
+        	String key = k;
+        	Object value = fieldsValuesMap.get(k);
+        	Predicate predicate = builder.and(builder.equal(rootEntry.get(key),value));
+        	predicateArray[counter] = predicate;
+        	counter++;
+		}
+        return predicateArray;
 	}
 }

--- a/video-processor/src/main/java/de/uhh/l2g/webservices/videoprocessor/model/VideoConversion.java
+++ b/video-processor/src/main/java/de/uhh/l2g/webservices/videoprocessor/model/VideoConversion.java
@@ -45,6 +45,9 @@ public class VideoConversion {
 	
 	@Column(updatable = false)
 	private Long sourceId;
+	
+	@Column(updatable = false)
+	private String tenant;
 
 	private String opencastId;
 
@@ -135,6 +138,20 @@ public class VideoConversion {
 	 */
 	public void setSourceId(Long sourceId) {
 		this.sourceId = sourceId;
+	}
+
+	/**
+	 * @return the tenant
+	 */
+	public String getTenant() {
+		return tenant;
+	}
+
+	/**
+	 * @param tenant the tanant to set
+	 */
+	public void setTenant(String tenant) {
+		this.tenant = tenant;
 	}
 
 	/**

--- a/video-processor/src/main/java/de/uhh/l2g/webservices/videoprocessor/model/VideoConversion.java
+++ b/video-processor/src/main/java/de/uhh/l2g/webservices/videoprocessor/model/VideoConversion.java
@@ -55,6 +55,8 @@ public class VideoConversion {
 	
 	private String targetDirectory;
 	
+	private String targetThumbnailDirectory;
+
 	@Transient
 	private String targetFilePath;
 	
@@ -189,12 +191,25 @@ public class VideoConversion {
 		return targetDirectory;
 	}
 
-
 	/**
 	 * @param targetDirectory the targetDirectory to set
 	 */
 	public void setTargetFilePath(String targetFilePath) {
 		this.targetDirectory = FilenameUtils.getFullPath(targetFilePath);
+	}
+	
+	/**
+	 * @return the getTargetThumbnailDirectory
+	 */
+	public String getTargetThumbnailDirectory() {
+		return targetThumbnailDirectory;
+	}
+
+	/**
+	 * @param targetThumbnailDirectory the targetThumbnailDirectory to set
+	 */
+	public void setTargetThumbnailDirectory(String targetThumbnailDirectory) {
+		this.targetThumbnailDirectory = targetThumbnailDirectory;
 	}
 	
 	/**

--- a/video-processor/src/main/java/de/uhh/l2g/webservices/videoprocessor/resources/VideoConversionResourceBySourceId.java
+++ b/video-processor/src/main/java/de/uhh/l2g/webservices/videoprocessor/resources/VideoConversionResourceBySourceId.java
@@ -1,5 +1,10 @@
 package de.uhh.l2g.webservices.videoprocessor.resources;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.ws.rs.NotFoundException;
+
 import de.uhh.l2g.webservices.videoprocessor.dao.GenericDao;
 import de.uhh.l2g.webservices.videoprocessor.filter.BasicAuthenticationFilter.Secured;
 import de.uhh.l2g.webservices.videoprocessor.filter.LoggingFilter.Logged;
@@ -13,8 +18,16 @@ import de.uhh.l2g.webservices.videoprocessor.model.VideoConversion;
 @Logged
 //@Secured
 public class VideoConversionResourceBySourceId extends VideoConversionResource {
-
-	public VideoConversionResourceBySourceId(Long sourceId) {
-		videoConversion = GenericDao.getInstance().getFirstByFieldValueOrderedDesc(VideoConversion.class, "sourceId",  sourceId, "startTime");
+	
+	public VideoConversionResourceBySourceId(Long sourceId, String tenant) {
+		this.tenant = tenant;
+		// get video conversion by source ID and tenant
+		Map<String, Object> map = new HashMap<String, Object>();
+		map.put("sourceId", sourceId);
+		map.put("tenant", tenant);
+		videoConversion = GenericDao.getInstance().getFirstByMultipleFieldsValuesOrderedDesc(VideoConversion.class, map, "startTime");
+		if (videoConversion == null) {
+            throw new NotFoundException();
+		}
 	}
 }

--- a/video-processor/src/main/java/de/uhh/l2g/webservices/videoprocessor/service/VideoConversionService.java
+++ b/video-processor/src/main/java/de/uhh/l2g/webservices/videoprocessor/service/VideoConversionService.java
@@ -331,13 +331,20 @@ public class VideoConversionService {
 		
 		// download to a temporary filename first
 		// the target file path consists of the image path and the original filename
-		String targetFilePath = Config.getInstance().getProperty("folder.thumbnails") + videoConversion.getFilename();
+		String targetFilePath = FilenameUtils.concat(getThumbnailDirectory(), videoConversion.getFilename());
 		downloadFile(createdFile, targetFilePath);
 		
 		GenericDao.getInstance().update(createdFile);
 		// rename the file to the final name with the necessary suffix right now, as there should be not changes in this short timeframe
-		createdFile = renameFilesToFinalFilename(createdFile, thumbnailSuffixWithoutExtension, Config.getInstance().getProperty("folder.thumbnails"));
+		createdFile = renameFilesToFinalFilename(createdFile, thumbnailSuffixWithoutExtension, getThumbnailDirectory());
 		GenericDao.getInstance().update(createdFile);
+	}
+	
+	/**
+	 * @return the thumbnail directory from request or config as fallback
+	 */
+	private String getThumbnailDirectory() {
+		return videoConversion.getTargetThumbnailDirectory() != null ? videoConversion.getTargetThumbnailDirectory() : Config.getInstance().getProperty("folder.thumbnails");
 	}
 
 	/**
@@ -669,7 +676,7 @@ public class VideoConversionService {
 			if (targetPath == null) {
 				targetFilePath = videoConversion.getTargetFilePath();
 			} else {
-				targetFilePath = targetPath + videoConversion.getFilename();
+				targetFilePath = FilenameUtils.concat(targetPath, videoConversion.getFilename());
 			}
 			// add the suffix to the basename (e.g. _m for thumbnails)
 			targetFilePath = FilenameHandler.addToBasename(targetFilePath, suffixWithoutExtension);


### PR DESCRIPTION
Multiple tenants now use the same video-processor. 
A tenant field is added to the database so the same source-id can be
used on different tenants. 
All requests are therefore checked for a custom Tenant header in the
request.