### PR TITLE
Extend L2GFileName check for sign video files

### DIFF
--- a/servlet-file-upload/src/main/java/com/hmkcode/MultipartRequestHandler.java
+++ b/servlet-file-upload/src/main/java/com/hmkcode/MultipartRequestHandler.java
@@ -186,7 +186,7 @@ public class MultipartRequestHandler {
 							}
 							//////////// ---- //////////// ---- ////////////
 							//new file -> item is lecture2go named file?
-							if (!SyntaxManager.isL2gFileName(itemName)) {
+							if (!SyntaxManager.isL2gFileName(itemName, isSignVideo)) {
 								itemName = generateL2gFileName(lectureseriesNumber, container, l2gDateTime, videoId, isSignVideo);
 								temp.setFileName(itemName);
 							}

--- a/servlet-file-upload/src/main/java/de/uhh/l2g/util/SyntaxManager.java
+++ b/servlet-file-upload/src/main/java/de/uhh/l2g/util/SyntaxManager.java
@@ -10,8 +10,11 @@ import java.util.regex.Pattern;
 
 public class SyntaxManager {
 
-	public static boolean isL2gFileName(String fileName){
+	public static boolean isL2gFileName(String fileName, boolean isSignVideo){
 		boolean isL2gFile=false;
+		if (isSignVideo) {
+			fileName = fileName.replace("_sign", "");
+		}
 		fileName = replaceIllegalFilenameCharacters(fileName);
 		//pick file container
 		String container = fileName.split("\\.")[fileName.split("\\.").length-1];


### PR DESCRIPTION
Check for legal L2G filename must succeed for sign video files. Check only succeeds if video file is marked as such (otherwise *_sign.mp4 is still not a legal file name).